### PR TITLE
fix: build before preview to avoid broken page

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
-    "preview": "astro build & astro preview",
+    "preview": "astro build && astro preview",
     "astro": "astro",
     "new-post": "node scripts/add-post.js"
   },


### PR DESCRIPTION
## Summary
- ensure `npm run preview` completes build before starting server

## Testing
- `npm run build`
- `npm run preview` (terminated)


------
https://chatgpt.com/codex/tasks/task_e_689ff680f0648333bb5aad986b7f71aa